### PR TITLE
Add engage-helm-chart v1.0.8 with internal ingress

### DIFF
--- a/charts/engage-helm-chart/Chart.yaml
+++ b/charts/engage-helm-chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: engage-helm-chart
 description: A Generic Engage Helm chart with configurable gRPC or HTTP health checks
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: "1.0.0"

--- a/charts/engage-helm-chart/templates/ingress.yaml
+++ b/charts/engage-helm-chart/templates/ingress.yaml
@@ -6,11 +6,9 @@ metadata:
   labels:
     app: {{ .Values.name }}
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.albName }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
 spec:
   ingressClassName: {{ .Values.ingress.class }}
   rules:


### PR DESCRIPTION
## Summary
- Bump engage-helm-chart to v1.0.8
- Change ingress ALB scheme from `internet-facing` to `internal` (matching eth-helm-chart 1.0.4 pattern)
- Remove `listen-ports` and `certificate-arn` annotations (not needed for internal ALB)

## Motivation
For use by p2p projects in `argocd-eth-prod-large-account` — all p2p services use `apps-internal` ALB group and should be exposed via internal ALB only.

## Test plan
- [x] `helm template` renders correctly with p2p-service values.yaml — verified internal scheme applied
- [ ] After merge, `chart-releaser` workflow should publish engage-helm-chart-1.0.8 to https://betkub.github.io/devops-helm/
- [ ] Update p2p kustomization.yaml files to version 1.0.8 once the chart is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)